### PR TITLE
Expand product code coverage

### DIFF
--- a/BitFlyer.Apis.Test/ProductCodeConsistencyTest.cs
+++ b/BitFlyer.Apis.Test/ProductCodeConsistencyTest.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BitFlyer.Apis;
+using Xunit;
+
+namespace BitFlyer.Apis.Test
+{
+    public class ProductCodeConsistencyTest
+    {
+        private static readonly string[] DocumentedProductCodes =
+        {
+            ProductCode.BtcJpy,
+            ProductCode.FxBtcJpy,
+            ProductCode.EthBtc,
+            ProductCode.EthJpy,
+            ProductCode.BchBtc,
+            ProductCode.BchJpy,
+            ProductCode.BtcUsd,
+            ProductCode.BtcEur,
+            ProductCode.MonaJpy,
+            ProductCode.MonaBtc,
+            ProductCode.LtcBtc,
+            ProductCode.XrpJpy,
+            ProductCode.XrpBtc,
+            ProductCode.XlmJpy,
+            ProductCode.XlmBtc,
+            ProductCode.XemJpy,
+            ProductCode.XemBtc,
+            ProductCode.BatJpy,
+            ProductCode.BatBtc,
+            ProductCode.OmgJpy,
+            ProductCode.OmgBtc,
+        };
+
+        [Fact]
+        public void ProductCode_AllConstantsMatchDocumentedList()
+        {
+            Assert.Equal(DocumentedProductCodes, ProductCode.All);
+
+            var constantValues = typeof(ProductCode)
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(field => field.IsLiteral && !field.IsInitOnly && field.FieldType == typeof(string))
+                .Select(field => (string)field.GetRawConstantValue())
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray();
+
+            var documentedValues = DocumentedProductCodes
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(documentedValues, constantValues);
+        }
+
+        [Fact]
+        public void RealtimeChannelsExistForEveryProductCode()
+        {
+            var channelFields = typeof(RealtimeChannel)
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(field => field.IsLiteral && !field.IsInitOnly && field.FieldType == typeof(string))
+                .ToDictionary(field => field.Name, field => (string)field.GetRawConstantValue(), StringComparer.Ordinal);
+
+            var channelDefinitions = new (string Suffix, string Prefix)[]
+            {
+                ("BoardSnapshot", RealtimeChannel.BoardSnapshotPrefix),
+                ("Board", RealtimeChannel.BoardPrefix),
+                ("Ticker", RealtimeChannel.TickerPrefix),
+                ("Executions", RealtimeChannel.ExecutionPrefix),
+            };
+
+            foreach (var productField in typeof(ProductCode)
+                         .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                         .Where(field => field.IsLiteral && !field.IsInitOnly && field.FieldType == typeof(string)))
+            {
+                var productCodeName = productField.Name;
+                var productCodeValue = (string)productField.GetRawConstantValue();
+
+                foreach (var (suffix, prefix) in channelDefinitions)
+                {
+                    var channelConstantName = suffix + productCodeName;
+                    Assert.True(channelFields.TryGetValue(channelConstantName, out var channelValue),
+                        $"RealtimeChannel.{channelConstantName} is missing.");
+
+                    var expectedValue = prefix + productCodeValue;
+
+                    Assert.Equal(expectedValue, channelValue);
+                }
+            }
+        }
+    }
+}

--- a/BitFlyer.Apis/ProductCode.cs
+++ b/BitFlyer.Apis/ProductCode.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace BitFlyer.Apis
@@ -8,9 +9,49 @@ namespace BitFlyer.Apis
         public const string BtcJpy = "BTC_JPY";
         public const string FxBtcJpy = "FX_BTC_JPY";
         public const string EthBtc = "ETH_BTC";
+        public const string EthJpy = "ETH_JPY";
         public const string BchBtc = "BCH_BTC";
+        public const string BchJpy = "BCH_JPY";
         public const string BtcUsd = "BTC_USD";
         public const string BtcEur = "BTC_EUR";
+        public const string MonaJpy = "MONA_JPY";
+        public const string MonaBtc = "MONA_BTC";
+        public const string LtcBtc = "LTC_BTC";
+        public const string XrpJpy = "XRP_JPY";
+        public const string XrpBtc = "XRP_BTC";
+        public const string XlmJpy = "XLM_JPY";
+        public const string XlmBtc = "XLM_BTC";
+        public const string XemJpy = "XEM_JPY";
+        public const string XemBtc = "XEM_BTC";
+        public const string BatJpy = "BAT_JPY";
+        public const string BatBtc = "BAT_BTC";
+        public const string OmgJpy = "OMG_JPY";
+        public const string OmgBtc = "OMG_BTC";
+
+        public static IReadOnlyList<string> All { get; } = new[]
+        {
+            BtcJpy,
+            FxBtcJpy,
+            EthBtc,
+            EthJpy,
+            BchBtc,
+            BchJpy,
+            BtcUsd,
+            BtcEur,
+            MonaJpy,
+            MonaBtc,
+            LtcBtc,
+            XrpJpy,
+            XrpBtc,
+            XlmJpy,
+            XlmBtc,
+            XemJpy,
+            XemBtc,
+            BatJpy,
+            BatBtc,
+            OmgJpy,
+            OmgBtc,
+        };
 
         public static async Task<string> GetBtcJpyThisWeek()
         {

--- a/BitFlyer.Apis/PubnubChannel.cs
+++ b/BitFlyer.Apis/PubnubChannel.cs
@@ -32,11 +32,25 @@ namespace BitFlyer.Apis
         public const string ExecutionsEthBtc = ExecutionPrefix + ProductCode.EthBtc;
         #endregion
 
+        #region EthJpy
+        public const string BoardSnapshotEthJpy = BoardSnapshotPrefix + ProductCode.EthJpy;
+        public const string BoardEthJpy = BoardPrefix + ProductCode.EthJpy;
+        public const string TickerEthJpy = TickerPrefix + ProductCode.EthJpy;
+        public const string ExecutionsEthJpy = ExecutionPrefix + ProductCode.EthJpy;
+        #endregion
+
         #region BchBtc
         public const string BoardSnapshotBchBtc = BoardSnapshotPrefix + ProductCode.BchBtc;
         public const string BoardBchBtc = BoardPrefix + ProductCode.BchBtc;
         public const string TickerBchBtc = TickerPrefix + ProductCode.BchBtc;
         public const string ExecutionsBchBtc = ExecutionPrefix + ProductCode.BchBtc;
+        #endregion
+
+        #region BchJpy
+        public const string BoardSnapshotBchJpy = BoardSnapshotPrefix + ProductCode.BchJpy;
+        public const string BoardBchJpy = BoardPrefix + ProductCode.BchJpy;
+        public const string TickerBchJpy = TickerPrefix + ProductCode.BchJpy;
+        public const string ExecutionsBchJpy = ExecutionPrefix + ProductCode.BchJpy;
         #endregion
 
         #region BtcUsd
@@ -51,6 +65,97 @@ namespace BitFlyer.Apis
         public const string BoardBtcEur = BoardPrefix + ProductCode.BtcEur;
         public const string TickerBtcEur = TickerPrefix + ProductCode.BtcEur;
         public const string ExecutionsBtcEur = ExecutionPrefix + ProductCode.BtcEur;
+        #endregion
+
+        #region MonaJpy
+        public const string BoardSnapshotMonaJpy = BoardSnapshotPrefix + ProductCode.MonaJpy;
+        public const string BoardMonaJpy = BoardPrefix + ProductCode.MonaJpy;
+        public const string TickerMonaJpy = TickerPrefix + ProductCode.MonaJpy;
+        public const string ExecutionsMonaJpy = ExecutionPrefix + ProductCode.MonaJpy;
+        #endregion
+
+        #region MonaBtc
+        public const string BoardSnapshotMonaBtc = BoardSnapshotPrefix + ProductCode.MonaBtc;
+        public const string BoardMonaBtc = BoardPrefix + ProductCode.MonaBtc;
+        public const string TickerMonaBtc = TickerPrefix + ProductCode.MonaBtc;
+        public const string ExecutionsMonaBtc = ExecutionPrefix + ProductCode.MonaBtc;
+        #endregion
+
+        #region LtcBtc
+        public const string BoardSnapshotLtcBtc = BoardSnapshotPrefix + ProductCode.LtcBtc;
+        public const string BoardLtcBtc = BoardPrefix + ProductCode.LtcBtc;
+        public const string TickerLtcBtc = TickerPrefix + ProductCode.LtcBtc;
+        public const string ExecutionsLtcBtc = ExecutionPrefix + ProductCode.LtcBtc;
+        #endregion
+
+        #region XrpJpy
+        public const string BoardSnapshotXrpJpy = BoardSnapshotPrefix + ProductCode.XrpJpy;
+        public const string BoardXrpJpy = BoardPrefix + ProductCode.XrpJpy;
+        public const string TickerXrpJpy = TickerPrefix + ProductCode.XrpJpy;
+        public const string ExecutionsXrpJpy = ExecutionPrefix + ProductCode.XrpJpy;
+        #endregion
+
+        #region XrpBtc
+        public const string BoardSnapshotXrpBtc = BoardSnapshotPrefix + ProductCode.XrpBtc;
+        public const string BoardXrpBtc = BoardPrefix + ProductCode.XrpBtc;
+        public const string TickerXrpBtc = TickerPrefix + ProductCode.XrpBtc;
+        public const string ExecutionsXrpBtc = ExecutionPrefix + ProductCode.XrpBtc;
+        #endregion
+
+        #region XlmJpy
+        public const string BoardSnapshotXlmJpy = BoardSnapshotPrefix + ProductCode.XlmJpy;
+        public const string BoardXlmJpy = BoardPrefix + ProductCode.XlmJpy;
+        public const string TickerXlmJpy = TickerPrefix + ProductCode.XlmJpy;
+        public const string ExecutionsXlmJpy = ExecutionPrefix + ProductCode.XlmJpy;
+        #endregion
+
+        #region XlmBtc
+        public const string BoardSnapshotXlmBtc = BoardSnapshotPrefix + ProductCode.XlmBtc;
+        public const string BoardXlmBtc = BoardPrefix + ProductCode.XlmBtc;
+        public const string TickerXlmBtc = TickerPrefix + ProductCode.XlmBtc;
+        public const string ExecutionsXlmBtc = ExecutionPrefix + ProductCode.XlmBtc;
+        #endregion
+
+        #region XemJpy
+        public const string BoardSnapshotXemJpy = BoardSnapshotPrefix + ProductCode.XemJpy;
+        public const string BoardXemJpy = BoardPrefix + ProductCode.XemJpy;
+        public const string TickerXemJpy = TickerPrefix + ProductCode.XemJpy;
+        public const string ExecutionsXemJpy = ExecutionPrefix + ProductCode.XemJpy;
+        #endregion
+
+        #region XemBtc
+        public const string BoardSnapshotXemBtc = BoardSnapshotPrefix + ProductCode.XemBtc;
+        public const string BoardXemBtc = BoardPrefix + ProductCode.XemBtc;
+        public const string TickerXemBtc = TickerPrefix + ProductCode.XemBtc;
+        public const string ExecutionsXemBtc = ExecutionPrefix + ProductCode.XemBtc;
+        #endregion
+
+        #region BatJpy
+        public const string BoardSnapshotBatJpy = BoardSnapshotPrefix + ProductCode.BatJpy;
+        public const string BoardBatJpy = BoardPrefix + ProductCode.BatJpy;
+        public const string TickerBatJpy = TickerPrefix + ProductCode.BatJpy;
+        public const string ExecutionsBatJpy = ExecutionPrefix + ProductCode.BatJpy;
+        #endregion
+
+        #region BatBtc
+        public const string BoardSnapshotBatBtc = BoardSnapshotPrefix + ProductCode.BatBtc;
+        public const string BoardBatBtc = BoardPrefix + ProductCode.BatBtc;
+        public const string TickerBatBtc = TickerPrefix + ProductCode.BatBtc;
+        public const string ExecutionsBatBtc = ExecutionPrefix + ProductCode.BatBtc;
+        #endregion
+
+        #region OmgJpy
+        public const string BoardSnapshotOmgJpy = BoardSnapshotPrefix + ProductCode.OmgJpy;
+        public const string BoardOmgJpy = BoardPrefix + ProductCode.OmgJpy;
+        public const string TickerOmgJpy = TickerPrefix + ProductCode.OmgJpy;
+        public const string ExecutionsOmgJpy = ExecutionPrefix + ProductCode.OmgJpy;
+        #endregion
+
+        #region OmgBtc
+        public const string BoardSnapshotOmgBtc = BoardSnapshotPrefix + ProductCode.OmgBtc;
+        public const string BoardOmgBtc = BoardPrefix + ProductCode.OmgBtc;
+        public const string TickerOmgBtc = TickerPrefix + ProductCode.OmgBtc;
+        public const string ExecutionsOmgBtc = ExecutionPrefix + ProductCode.OmgBtc;
         #endregion
 
         #region BtcJpyThisWeek


### PR DESCRIPTION
## Summary
- add missing Lightning product codes to `ProductCode` and expose a consolidated `All` list
- publish realtime board/ticker/execution channel constants for every documented market
- add unit tests that keep the product code and realtime channel constants aligned with the documented market list

## Testing
- `dotnet test --filter ProductCodeConsistencyTest` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebca3dd56c832bb378ca23ca3deb49