### PR TITLE
Document API reference snapshot and coverage gaps

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1,7 +1,7 @@
 # Plan to update bitFlyer .NET client according to Lightning API docs
 
 ## 0. Documentation acquisition and baselining
-- [ ] Access the official Lightning REST documentation (https://lightning.bitflyer.com/docs) **and** the realtime API documentation (https://bf-lightning-api.readme.io/docs/realtime-api) on demand when research is required.
+- [x] Access the official Lightning REST documentation (https://lightning.bitflyer.com/docs) **and** the realtime API documentation (https://bf-lightning-api.readme.io/docs/realtime-api) on demand when research is required.
   - Direct requests now succeed from this environment:
     - `curl -I https://lightning.bitflyer.com/docs` → HTTP 200 via Envoy proxy.
     - `curl -I https://bf-lightning-api.readme.io/docs/realtime-api` → HTTP 200 with Cloudflare headers.
@@ -12,10 +12,14 @@
     - Investigate whether bitFlyer publishes downloadable PDFs, an OpenAPI spec, or a GitHub repo mirror that can be tracked for future updates, and document references to those resources instead of mirroring them locally.
   - Ensure contributors understand that the latest authoritative information is always the live documentation, so links should remain in project docs to guide future updates.
 - [ ] From the docs, extract the canonical lists of HTTP endpoints, websocket channels (public and private), request/response schemas, and enumerations for later comparison.
+  - [x] Capture REST endpoint list snapshot in `docs/API_REFERENCE_SNAPSHOT.md`.
+  - [ ] Retrieve websocket channel inventory (requires alternate scraping approach).
+  - [ ] Enumerate request/response schema deltas.
+  - [ ] Update enumeration lists (product codes, etc.).
 
 ## 1. Gap analysis between documentation and current implementation
-- [ ] Build a coverage matrix mapping every documented HTTP public endpoint (e.g., `/v1/getticker`, `/v1/getboard`, `/v1/getexecutions`, `/v1/getmarkets`, regional chat endpoints, etc.) to the methods available under `BitFlyer.Apis/PublicApis`. Flag any documented endpoints or query parameters missing in the client (including recent additions such as new market listings, pagination parameters, or throttle information).
-- [ ] Perform the same coverage check for private endpoints described under “Private API” in the docs (e.g., `/v1/me/sendchildorder`, `/v1/me/getchildorders`, `/v1/me/getbalance`, `/v1/me/getwithdrawals`, `/v1/me/getpermissions`, `/v1/me/sendcoin`, `/v1/me/withdraw`). Highlight newer endpoints that are currently absent—particularly margin- or staking-related calls that were added after this client was last updated.
+- [x] Build a coverage matrix mapping every documented HTTP public endpoint (e.g., `/v1/getticker`, `/v1/getboard`, `/v1/getexecutions`, `/v1/getmarkets`, regional chat endpoints, etc.) to the methods available under `BitFlyer.Apis/PublicApis`. Flag any documented endpoints or query parameters missing in the client (including recent additions such as new market listings, pagination parameters, or throttle information).
+- [x] Perform the same coverage check for private endpoints described under “Private API” in the docs (e.g., `/v1/me/sendchildorder`, `/v1/me/getchildorders`, `/v1/me/getbalance`, `/v1/me/getwithdrawals`, `/v1/me/getpermissions`, `/v1/me/sendcoin`, `/v1/me/withdraw`). Highlight newer endpoints that are currently absent—particularly margin- or staking-related calls that were added after this client was last updated.
 - [ ] Review websocket channel documentation (`lightning_board_{product_code}`, `lightning_ticker_{product_code}`, `lightning_executions_{product_code}`, private channels requiring auth, etc.) from the realtime docs and compare with the helper methods available in `RealtimeApi`. Note any authentication requirements or additional channels (e.g., board snapshot or FX-specific feeds) that need new convenience wrappers.
 - [ ] Compare documented data models against classes in `ResponseData` and `RequestData`. Capture any new response fields (e.g., additional collateral metrics, event identifiers, settlement prices) or newly required request members so they can be reflected in the data contracts.
 - [ ] Review enumerations (`ProductCode`, `CurrencyCode`, `BoardStates`, `BitflyerSystemHealth`, etc.) against the doc’s lists to make sure any new currencies/products/status values are represented.
@@ -31,7 +35,7 @@
 - [ ] Refresh developer-facing documentation (`README.md` and samples under `BitFlyer.Sample`) to showcase the new capabilities and note any breaking changes or additional setup (e.g., websocket auth steps).
 
 ## 3. Deliverables and verification
-- [ ] Document the coverage matrix and summarize deltas in a new `docs/API_Coverage.md` (or similar) file so future maintainers can quickly see alignment with the official docs.
+- [x] Document the coverage matrix and summarize deltas in a new `docs/API_Coverage.md` (or similar) file so future maintainers can quickly see alignment with the official docs.
 - [ ] Ensure backward compatibility: version the NuGet package appropriately (minor or major bump depending on breaking changes) and communicate deprecations per doc guidance.
 - [ ] Perform manual sanity tests against the live API (respecting rate limits and sandbox availability) for at least one endpoint in each category (public, private, websocket) before releasing.
 - [ ] Coordinate with stakeholders for review of security-sensitive changes (e.g., handling of API secrets in websocket auth) in case the docs introduced new requirements.

--- a/docs/API_Coverage.md
+++ b/docs/API_Coverage.md
@@ -1,0 +1,57 @@
+# API Coverage Matrix
+
+This document tracks the alignment between the official bitFlyer Lightning API documentation (snapshot 2025-10-14) and the current client implementation.
+
+## Public REST Endpoints
+
+| Endpoint (Docs) | Implemented Method | Coverage Status | Notes |
+| --- | --- | --- | --- |
+| `GET /v1/getmarkets` / `GET /v1/markets` | `PublicApi.GetMarkets` | ✅ | Client targets `/v1/markets`; docs list both legacy (`getmarkets`) and new path. |
+| `GET /v1/getmarkets/usa` / `GET /v1/markets/usa` | `PublicApi.GetMarketsUsa` | ✅ | Same path alias consideration as above. |
+| `GET /v1/getmarkets/eu` / `GET /v1/markets/eu` | `PublicApi.GetMarketsEu` | ✅ | — |
+| `GET /v1/getboard` / `GET /v1/board` | `PublicApi.GetBoard` | ✅ | — |
+| `GET /v1/getticker` / `GET /v1/ticker` | `PublicApi.GetTicker` | ✅ | — |
+| `GET /v1/getexecutions` / `GET /v1/executions` | `PublicApi.GetExecutions` | ✅ | Supports `count`, `before`, `after`. |
+| `GET /v1/getboardstate` | `PublicApi.GetBoardState` | ✅ | — |
+| `GET /v1/gethealth` | `PublicApi.GetHealth` | ⚠️ | Method defaults `product_code` to `BTC_JPY`; docs note optional product code parameter. Verify compatibility. |
+| `GET /v1/getfundingrate` | — | ❌ | No wrapper or response DTO exists. |
+| `GET /v1/getcorporateleverage` | — | ❌ | No wrapper or response DTO exists. |
+| `GET /v1/getchats` | `PublicApi.GetChat` | ✅ | Supports optional `from_date`. |
+| `GET /v1/getchats/usa` | `PublicApi.GetChatUsa` | ✅ | Supports optional `from_date`. |
+| `GET /v1/getchats/eu` | `PublicApi.GetChatEu` | ✅ | Supports optional `from_date`. |
+
+## Private REST Endpoints
+
+| Endpoint (Docs) | Implemented Method | Coverage Status | Notes |
+| --- | --- | --- | --- |
+| `GET /v1/me/getpermissions` | `PrivateApi.GetPermissions` | ✅ | Method returns `string[]`. |
+| `GET /v1/me/getbalance` | `PrivateApi.GetBalance` | ✅ | — |
+| `GET /v1/me/getcollateral` | `PrivateApi.GetCollateral` | ✅ | — |
+| `GET /v1/me/getcollateralaccounts` | `PrivateApi.GetCollateralAccounts` | ✅ | — |
+| `GET /v1/me/getaddresses` | `PrivateApi.GetAddresses` | ✅ | — |
+| `GET /v1/me/getcoinins` | `PrivateApi.GetCoinIns` | ✅ | Supports pagination params. |
+| `GET /v1/me/getcoinouts` | `PrivateApi.GetCoinOuts` | ✅ | Supports pagination params. |
+| `GET /v1/me/getbankaccounts` | `PrivateApi.GetBankAccounts` | ✅ | — |
+| `GET /v1/me/getdeposits` | `PrivateApi.GetDeposits` | ✅ | — |
+| `POST /v1/me/withdraw` | `PrivateApi.Withdraw` | ✅ | Returns `WithdrawResult`. |
+| `GET /v1/me/getwithdrawals` | `PrivateApi.GetWithdrawals` | ✅ | Supports pagination params. |
+| `POST /v1/me/sendchildorder` | `PrivateApi.SendChildOrder` | ✅ | — |
+| `POST /v1/me/cancelchildorder` | `PrivateApi.CancelChildOrder` | ✅ | — |
+| `POST /v1/me/sendparentorder` | `PrivateApi.SendParentOrder` | ✅ | — |
+| `POST /v1/me/cancelparentorder` | `PrivateApi.CancelParentOrder` | ✅ | — |
+| `POST /v1/me/cancelallchildorders` | `PrivateApi.CancelAllOrders` | ✅ | — |
+| `GET /v1/me/getchildorders` | `PrivateApi.GetChildOrders` / `GetChildOrder` | ✅ | Provides filtering by state, pagination. |
+| `GET /v1/me/getparentorders` | `PrivateApi.GetParentOrders` | ✅ | Supports filter parameters. |
+| `GET /v1/me/getparentorder` | `PrivateApi.GetParentOrder` | ✅ | — |
+| `GET /v1/me/getexecutions` | `PrivateApi.GetExecutions` | ✅ | — |
+| `GET /v1/me/getbalancehistory` | `PrivateApi.GetBalanceHistory` | ✅ | Supports pagination & currency filters. |
+| `GET /v1/me/getpositions` | `PrivateApi.GetPositions` | ✅ | Accepts product code. |
+| `GET /v1/me/getcollateralhistory` | `PrivateApi.GetCollateralHistory` | ✅ | Supports pagination. |
+| `GET /v1/me/gettradingcommission` | `PrivateApi.GetTradingCommission` | ✅ | Accepts product code. |
+| `POST /v1/me/sendcoin` | `PrivateApi.SendCoin` | ⚠️ | Method exists; docs snapshot lacked entry—confirm latest documentation references this endpoint. |
+
+## Realtime Channels
+
+The ReadMe-hosted realtime documentation relies on client-side rendering. Static retrieval did not expose the channel list; therefore coverage for websocket helpers is **pending manual extraction**. Follow-up action:
+1. Investigate ReadMe API export or alternative scrape approach.
+2. Compare against `RealtimeApi` helper constants (`RealtimeChannel` enum) once the channel list is available.

--- a/docs/API_REFERENCE_SNAPSHOT.md
+++ b/docs/API_REFERENCE_SNAPSHOT.md
@@ -1,0 +1,54 @@
+# bitFlyer Lightning API Reference Snapshot (2025-10-14)
+
+This document captures the canonical endpoint and channel names observed from the official documentation on 2025-10-14 (UTC). When the live documentation diverges from this snapshot, treat the live site as authoritative and refresh these notes.
+
+## REST Endpoints
+
+### Public Endpoints
+- `GET /v1/getmarkets`
+- `GET /v1/markets`
+- `GET /v1/getmarkets/usa`
+- `GET /v1/markets/usa`
+- `GET /v1/getmarkets/eu`
+- `GET /v1/markets/eu`
+- `GET /v1/getboard`
+- `GET /v1/board`
+- `GET /v1/getticker`
+- `GET /v1/ticker`
+- `GET /v1/getexecutions`
+- `GET /v1/executions`
+- `GET /v1/getboardstate`
+- `GET /v1/gethealth`
+- `GET /v1/getfundingrate`
+- `GET /v1/getcorporateleverage`
+- `GET /v1/getchats`
+- `GET /v1/getchats/usa`
+- `GET /v1/getchats/eu`
+
+### Private Endpoints
+- `GET /v1/me/getpermissions`
+- `GET /v1/me/getbalance`
+- `GET /v1/me/getcollateral`
+- `GET /v1/me/getcollateralaccounts`
+- `GET /v1/me/getaddresses`
+- `GET /v1/me/getcoinins`
+- `GET /v1/me/getcoinouts`
+- `GET /v1/me/getbankaccounts`
+- `GET /v1/me/getdeposits`
+- `POST /v1/me/withdraw`
+- `GET /v1/me/getwithdrawals`
+- `POST /v1/me/sendchildorder`
+- `POST /v1/me/cancelchildorder`
+- `POST /v1/me/sendparentorder`
+- `POST /v1/me/cancelparentorder`
+- `POST /v1/me/cancelallchildorders`
+- `GET /v1/me/getchildorders`
+- `GET /v1/me/getparentorders`
+- `GET /v1/me/getparentorder`
+- `GET /v1/me/getexecutions`
+- `GET /v1/me/getbalancehistory`
+- `GET /v1/me/getpositions`
+- `GET /v1/me/getcollateralhistory`
+- `GET /v1/me/gettradingcommission`
+
+> **Pending**: The realtime documentation requires client-side rendering, so the websocket channel list could not be captured via static download. Investigate an alternative retrieval method (e.g., ReadMe API export) in a follow-up task.

--- a/docs/SOURCE_NOTES.md
+++ b/docs/SOURCE_NOTES.md
@@ -1,0 +1,13 @@
+# Source Retrieval Notes
+
+## Official Documentation Requests
+- **https://lightning.bitflyer.com/docs**
+  - Accessed: 2025-10-14 (UTC)
+  - Method: `curl -I`
+  - Response: HTTP 200 via Envoy; `content-type: text/html; charset=utf-8`; `strict-transport-security: max-age=31536000`.
+- **https://bf-lightning-api.readme.io/docs/realtime-api**
+  - Accessed: 2025-10-14 (UTC)
+  - Method: `curl -I`
+  - Response: HTTP 200 via Envoy → Render; Cloudflare `cf-ray: 98e8c3faf98379d9-ORD`; rate limit headers present (`x-ratelimit-limit: 100`).
+
+These endpoints remain the canonical references for REST and realtime channel specifications. Download raw assets on demand only; do not commit them to the repository.


### PR DESCRIPTION
## Summary
- record REST endpoint lists from the official Lightning API documentation in `docs/API_REFERENCE_SNAPSHOT.md` and log retrieval metadata for future updates
- add `docs/API_Coverage.md` to highlight implemented endpoints versus documented ones, calling out missing public APIs such as `getfundingrate` and `getcorporateleverage`
- mark completed research tasks in `PLANS.md`, including a note to pursue websocket channel extraction separately

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ee86e5a1e4832b8b9a74ea6c4696b9